### PR TITLE
Fixed pause and unpause on reset

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2021 authors of kanzchip-8, licenced under MIT licence
-
+import sys
 import tkinter as tk
 from tkinter import filedialog
 
@@ -95,8 +95,18 @@ def main():
     clock = pygame.time.Clock()
     while True:
         clock.tick(60)  # run at 60 fps
-        menu.mainloop(screen.DISPLAY, bgfun=None, clear_surface=False,
-                      disable_loop=True, fps_limit=0)
+
+        events = pygame.event.get()
+        for event in events:
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                sys.exit()
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                screen.paused = not screen.paused
+
+        if menu.is_enabled():
+            menu.draw(screen.DISPLAY)
+            menu.update(events)
 
         if screen.paused:
             pygame.display.set_caption(f"{title}     PAUSED")

--- a/src/instruction_interpreter.py
+++ b/src/instruction_interpreter.py
@@ -61,6 +61,7 @@ class InstructionInterpreter:
         self.program_counter = PROGRAM_START
         self.stack = [0] * 16
         self.stack_pointer = 0
+        self.screen.paused = False
 
     def next_instruction(self):
         instruction = self.memory[self.program_counter] << 8

--- a/src/screen.py
+++ b/src/screen.py
@@ -29,12 +29,6 @@ class Screen:
 
     # Run spin in main loop to check for pygame events and update screen
     def spin(self):
-        for event in pygame.event.get():
-            if event.type == QUIT:
-                pygame.quit()
-                sys.exit()
-            elif event.type == KEYDOWN and event.key == pygame.K_ESCAPE:
-                self.paused = not self.paused
         # Redraw screen
         for y in range(32):
             for x in range(64):

--- a/src/screen.py
+++ b/src/screen.py
@@ -1,9 +1,6 @@
 # Copyright (C) 2021 authors of kanzchip-8, licenced under MIT licence
 
-import sys
-
 import pygame
-from pygame.locals import *
 
 from src.log import logger
 


### PR DESCRIPTION
Moved events to main loop and call `menu.draw` and `menu.update` manually
instead of using `menu.mainloop`.
Like this example https://github.com/ppizarror/pygame-menu/blob/master/pygame_menu/examples/game_selector.py#L117